### PR TITLE
Minor improvements

### DIFF
--- a/Configuration/Id.php
+++ b/Configuration/Id.php
@@ -24,7 +24,7 @@ class Id
      */
     public function __construct($fieldName)
     {
-        $this->fieldName = $fieldName;
+        $this->fieldName = (string) $fieldName;
     }
 
     /**
@@ -32,6 +32,6 @@ class Id
      */
     public function getFieldName()
     {
-        return $this->fieldName;
+        return (string) $this->fieldName;
     }
 }

--- a/EventListener/Serializer/JsonEventSubscriber.php
+++ b/EventListener/Serializer/JsonEventSubscriber.php
@@ -359,11 +359,11 @@ class JsonEventSubscriber implements EventSubscriberInterface
      * @param ClassMetadata $classMetadata
      * @param               $object
      *
-     * @return mixed
+     * @return string
      */
     protected function getId(ClassMetadata $classMetadata, $object)
     {
-        return $this->propertyAccessor->getValue($object, $classMetadata->getIdField());
+        return (string) $this->propertyAccessor->getValue($object, $classMetadata->getIdField());
     }
 
     /**

--- a/Tests/Fixtures/Order.php
+++ b/Tests/Fixtures/Order.php
@@ -13,26 +13,44 @@ use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer\Annotation as JMS;
 use Mango\Bundle\JsonApiBundle\Configuration\Annotation as JsonApi;
 
-/** @JsonApi\Resource(type="order", showLinkSelf=false) */
+/**
+ * @JsonApi\Resource(type="order", showLinkSelf=false)
+ *
+ * @author Ruslan Zavacky <ruslan.zavacky@gmail.com>
+ */
 class Order
 {
     /**
      * @JsonApi\Id()
      * @JMS\Type("string")
+     *
+     * @var string
      */
     private $id;
 
-    /** @JMS\Type("string") */
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
     private $email;
 
-    /** @JMS\Type("string") */
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
     private $phone;
 
-    /** @JMS\Type("string") */
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
     private $adminComments;
 
     /**
-     * @JsonApi\Relationship(includeByDefault="true", showLinkSelf=false, showLinkRelated=false)
+     * @JsonApi\Relationship(includeByDefault=true, showLinkSelf=false, showLinkRelated=false)
      * @JMS\Type("Mango\Bundle\JsonApiBundle\Tests\Fixtures\OrderAddress")
      *
      * @var OrderAddress
@@ -40,7 +58,7 @@ class Order
     private $address;
 
     /**
-     * @JsonApi\Relationship(includeByDefault="true", showLinkSelf=false, showLinkRelated=false)
+     * @JsonApi\Relationship(includeByDefault=true, showLinkSelf=false, showLinkRelated=false)
      * @JMS\Type("Mango\Bundle\JsonApiBundle\Tests\Fixtures\OrderPaymentAbstract")
      *
      * @var OrderPaymentAbstract
@@ -48,26 +66,39 @@ class Order
     private $payment;
 
     /**
-     * @JsonApi\Relationship(includeByDefault="true", showLinkSelf=false, showLinkRelated=false)
+     * @JsonApi\Relationship(includeByDefault=true, showLinkSelf=false, showLinkRelated=false)
      * @JMS\Type("array<Mango\Bundle\JsonApiBundle\Tests\Fixtures\OrderItem>")
      *
      * @var OrderItem[]
      */
     private $items;
 
+    /**
+     * Order constructor
+     */
     public function __construct()
     {
         $this->items = new ArrayCollection();
     }
 
+    /**
+     * @return string
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
     public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
@@ -79,15 +110,19 @@ class Order
     }
 
     /**
-     * @param mixed $email
+     * @param string $email
+     *
+     * @return $this
      */
     public function setEmail($email)
     {
         $this->email = $email;
+
+        return $this;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getPhone()
     {
@@ -95,15 +130,18 @@ class Order
     }
 
     /**
-     * @param mixed $phone
+     * @param string $phone
+     * @return $this
      */
     public function setPhone($phone)
     {
         $this->phone = $phone;
+
+        return $this;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getAdminComments()
     {
@@ -111,15 +149,19 @@ class Order
     }
 
     /**
-     * @param mixed $adminComments
+     * @param string $adminComments
+     *
+     * @return $this
      */
     public function setAdminComments($adminComments)
     {
         $this->adminComments = $adminComments;
+
+        return $this;
     }
 
     /**
-     * @return mixed
+     * @return OrderAddress
      */
     public function getAddress()
     {
@@ -127,11 +169,15 @@ class Order
     }
 
     /**
-     * @param mixed $address
+     * @param string $address
+     *
+     * @return $this
      */
     public function setAddress($address)
     {
         $this->address = $address;
+
+        return $this;
     }
 
     /**
@@ -144,14 +190,18 @@ class Order
 
     /**
      * @param OrderPaymentAbstract $payment
+     *
+     * @return $this
      */
-    public function setPayment($payment)
+    public function setPayment(OrderPaymentAbstract $payment)
     {
         $this->payment = $payment;
+
+        return $this;
     }
 
     /**
-     * @return array
+     * @return ArrayCollection|OrderItem[]
      */
     public function getItems()
     {
@@ -159,10 +209,14 @@ class Order
     }
 
     /**
-     * @param array $items
+     * @param ArrayCollection|OrderItem[] $items
+     *
+     * @return $this
      */
-    public function setItems($items)
+    public function setItems(ArrayCollection $items)
     {
         $this->items = $items;
+
+        return $this;
     }
 }

--- a/Tests/Fixtures/OrderAddress.php
+++ b/Tests/Fixtures/OrderAddress.php
@@ -12,30 +12,50 @@ namespace Mango\Bundle\JsonApiBundle\Tests\Fixtures;
 use JMS\Serializer\Annotation as JMS;
 use Mango\Bundle\JsonApiBundle\Configuration\Annotation as JsonApi;
 
-/** @JsonApi\Resource(type="order/address", showLinkSelf=false) */
+/**
+ * @JsonApi\Resource(type="order/address", showLinkSelf=false)
+ *
+ * @author Ruslan Zavacky <ruslan.zavacky@gmail.com>
+ */
 class OrderAddress
 {
     /**
      * @JsonApi\Id()
      * @JMS\Type("string")
+     *
+     * @var string
      */
     private $id;
 
-    /** @JMS\Type("string") */
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
     private $street;
 
+    /**
+     * @return string
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
     public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getStreet()
     {
@@ -43,10 +63,13 @@ class OrderAddress
     }
 
     /**
-     * @param mixed $street
+     * @param string $street
+     *
+     * @return $this
      */
     public function setStreet($street)
     {
         $this->street = $street;
+        return $this;
     }
 }

--- a/Tests/Fixtures/OrderItem.php
+++ b/Tests/Fixtures/OrderItem.php
@@ -12,30 +12,50 @@ namespace Mango\Bundle\JsonApiBundle\Tests\Fixtures;
 use JMS\Serializer\Annotation as JMS;
 use Mango\Bundle\JsonApiBundle\Configuration\Annotation as JsonApi;
 
-/** @JsonApi\Resource(type="order/item", showLinkSelf=false) */
+/**
+ * @JsonApi\Resource(type="order/item", showLinkSelf=false)
+ *
+ * @author Ruslan Zavacky <ruslan.zavacky@gmail.com>
+ */
 class OrderItem
 {
     /**
      * @JsonApi\Id()
      * @JMS\Type("string")
+     *
+     * @var string
      */
     private $id;
 
-    /** @JMS\Type("string") */
+    /**
+     * @JMS\Type("string")
+     *
+     * @var string
+     */
     private $title;
 
+    /**
+     * @return string
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
     public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getTitle()
     {
@@ -43,10 +63,14 @@ class OrderItem
     }
 
     /**
-     * @param mixed $title
+     * @param string $title
+     *
+     * @return $this
      */
     public function setTitle($title)
     {
         $this->title = $title;
+
+        return $this;
     }
 }

--- a/Tests/Fixtures/OrderPaymentAbstract.php
+++ b/Tests/Fixtures/OrderPaymentAbstract.php
@@ -32,26 +32,45 @@ abstract class OrderPaymentAbstract
     /**
      * @JsonApi\Id()
      * @JMS\Type("string")
+     *
+     * @var string
      */
     private $id;
 
-    /** @JMS\Type("float") */
+    /**
+     * @JMS\Type("float")
+     *
+     * @var float
+     */
     private $amount;
 
+    /**
+     * @var string
+     */
     protected $type;
 
+    /**
+     * @return string
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $id
+     *
+     * @return $this
+     */
     public function setId($id)
     {
         $this->id = $id;
+
+        return $this;
     }
 
     /**
-     * @return mixed
+     * @return float
      */
     public function getAmount()
     {
@@ -59,11 +78,17 @@ abstract class OrderPaymentAbstract
     }
 
     /**
-     * @param mixed $amount
+     * Set amount
+     *
+     * @param float $amount
+     *
+     * @return $this
      */
     public function setAmount($amount)
     {
         $this->amount = $amount;
+
+        return $this;
     }
 
     /**

--- a/Tests/Serializer/SerializerTest.php
+++ b/Tests/Serializer/SerializerTest.php
@@ -8,6 +8,7 @@
 
 namespace Mango\Bundle\JsonApiBundle\Tests\Serializer;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer;
 use Mango\Bundle\JsonApiBundle\Serializer\Serializer as JsonApiSerializer;
 use Mango\Bundle\JsonApiBundle\Tests\Fixtures\Order;
@@ -27,6 +28,8 @@ use Mango\Bundle\JsonApiBundle\Tests\TestCase;
  */
 class SerializerTest extends TestCase
 {
+    const FORMAT_JSON = 'json';
+
     /**
      * {@inheritdoc}
      */
@@ -42,23 +45,23 @@ class SerializerTest extends TestCase
      */
     public function testSimpleSerialize()
     {
-        $order = new Order();
-        $order->setId(1);
-        $order->setEmail('test@example.com');
-        $order->setPhone('+440000000000');
-        $order->setAdminComments('Test comments that might be longer that ordinary text.');
-        $order->setAddress(null);
+        $order = (new Order())
+            ->setId(1)
+            ->setEmail('test@example.com')
+            ->setPhone('+440000000000')
+            ->setAdminComments('Test comments that might be longer that ordinary text.')
+            ->setAddress(null);
 
         $serialized = $this->jsonApiSerializer->serialize(
             $order,
-            'json',
+            self::FORMAT_JSON,
             Serializer\SerializationContext::create()->setSerializeNull(true)
         );
 
         $this->assertSame(json_decode($serialized, 1), [
             'data' => [
                 'type' => 'order',
-                'id' => 1,
+                'id' => '1',
                 'attributes' => [
                     'email' => 'test@example.com',
                     'phone' => '+440000000000',
@@ -86,27 +89,27 @@ class SerializerTest extends TestCase
      */
     public function testSerializeWithRelationship()
     {
-        $orderAddress = new OrderAddress();
-        $orderAddress->setId(2);
-        $orderAddress->setStreet('Street Address 510');
+        $orderAddress = (new OrderAddress())
+            ->setId(2)
+            ->setStreet('Street Address 510');
 
-        $order = new Order();
-        $order->setId(1);
-        $order->setEmail('test@example.com');
-        $order->setPhone('+440000000000');
-        $order->setAdminComments('Test comments that might be longer that ordinary text.');
-        $order->setAddress($orderAddress);
+        $order = (new Order())
+            ->setId(1)
+            ->setEmail('test@example.com')
+            ->setPhone('+440000000000')
+            ->setAdminComments('Test comments that might be longer that ordinary text.')
+            ->setAddress($orderAddress);
 
         $serialized = $this->jsonApiSerializer->serialize(
             $order,
-            'json',
+            self::FORMAT_JSON,
             Serializer\SerializationContext::create()->setSerializeNull(true)
         );
 
         $this->assertSame(json_decode($serialized, 1), [
             'data' => [
                 'type' => 'order',
-                'id' => 1,
+                'id' => '1',
                 'attributes' => [
                     'email' => 'test@example.com',
                     'phone' => '+440000000000',
@@ -116,7 +119,7 @@ class SerializerTest extends TestCase
                     'address' => [
                         'data' => [
                             'type' => 'order/address',
-                            'id' => 2,
+                            'id' => '2',
                         ],
                     ],
                     'payment' => [
@@ -130,7 +133,7 @@ class SerializerTest extends TestCase
             'included' => [
                 [
                     'type' => 'order/address',
-                    'id' => 2,
+                    'id' => '2',
                     'attributes' => [
                         'street' => 'Street Address 510',
                     ]
@@ -146,36 +149,36 @@ class SerializerTest extends TestCase
      */
     public function testSerializeWithOneToManyRelationship()
     {
-        $orderAddress = new OrderAddress();
-        $orderAddress->setId(2);
-        $orderAddress->setStreet('Street Address 510');
+        $orderAddress = (new OrderAddress())
+            ->setId(2)
+            ->setStreet('Street Address 510');
 
-        $orderItem1 = new OrderItem();
-        $orderItem1->setId(1);
-        $orderItem1->setTitle('Item 1');
+        $orderItem1 = (new OrderItem())
+            ->setId(1)
+            ->setTitle('Item 1');
 
-        $orderItem2 = new OrderItem();
-        $orderItem2->setId(2);
-        $orderItem2->setTitle('Item 2');
+        $orderItem2 = (new OrderItem())
+            ->setId(2)
+            ->setTitle('Item 2');
 
-        $order = new Order();
-        $order->setId(1);
-        $order->setEmail('test@example.com');
-        $order->setPhone('+440000000000');
-        $order->setAdminComments('Test comments that might be longer that ordinary text.');
-        $order->setAddress($orderAddress);
-        $order->setItems([$orderItem1, $orderItem2]);
+        $order = (new Order())
+            ->setId(1)
+            ->setEmail('test@example.com')
+            ->setPhone('+440000000000')
+            ->setAdminComments('Test comments that might be longer that ordinary text.')
+            ->setAddress($orderAddress)
+            ->setItems(new ArrayCollection([$orderItem1, $orderItem2]));
 
         $serialized = $this->jsonApiSerializer->serialize(
             $order,
-            'json',
+            self::FORMAT_JSON,
             Serializer\SerializationContext::create()->setSerializeNull(true)
         );
 
         $this->assertSame(json_decode($serialized, 1), [
             'data' => [
                 'type' => 'order',
-                'id' => 1,
+                'id' => '1',
                 'attributes' => [
                     'email' => 'test@example.com',
                     'phone' => '+440000000000',
@@ -185,7 +188,7 @@ class SerializerTest extends TestCase
                     'address' => [
                         'data' => [
                             'type' => 'order/address',
-                            'id' => 2,
+                            'id' => '2',
                         ],
                     ],
                     'payment' => [
@@ -195,11 +198,11 @@ class SerializerTest extends TestCase
                         'data' => [
                             [
                                 'type' => 'order/item',
-                                'id' => 1,
+                                'id' => '1',
                             ],
                             [
                                 'type' => 'order/item',
-                                'id' => 2,
+                                'id' => '2',
                             ],
                         ]
                     ]
@@ -208,21 +211,21 @@ class SerializerTest extends TestCase
             'included' => [
                 [
                     'type' => 'order/address',
-                    'id' => 2,
+                    'id' => '2',
                     'attributes' => [
                         'street' => 'Street Address 510',
                     ]
                 ],
                 [
                     'type' => 'order/item',
-                    'id' => 1,
+                    'id' => '1',
                     'attributes' => [
                         'title' => 'Item 1',
                     ]
                 ],
                 [
                     'type' => 'order/item',
-                    'id' => 2,
+                    'id' => '2',
                     'attributes' => [
                         'title' => 'Item 2',
                     ]
@@ -240,28 +243,28 @@ class SerializerTest extends TestCase
     {
         $this->markTestSkipped('WIP');
 
-        $cardPayment = new OrderPaymentCard();
-        $cardPayment->setId(1);
-        $cardPayment->setAmount(10.00);
+        $cardPayment = (new OrderPaymentCard())
+            ->setId(1)
+            ->setAmount(10.00);
 
-        $cashPayment = new OrderPaymentCash();
-        $cashPayment->setId(2);
-        $cashPayment->setAmount(20.00);
+        $cashPayment = (new OrderPaymentCash())
+            ->setId(2)
+            ->setAmount(20.00);
 
-        $order = new Order();
-        $order->setId(1);
-        $order->setPayment($cardPayment);
+        $order = (new Order())
+            ->setId(1)
+            ->setPayment($cardPayment);
 
         $serialized = $this->jsonApiSerializer->serialize(
             $order,
-            'json',
+            self::FORMAT_JSON,
             Serializer\SerializationContext::create()->setSerializeNull(true)
         );
 
         $this->assertSame(json_decode($serialized, 1), [
             'data' => [
                 'type' => 'order',
-                'id' => 1,
+                'id' => '1',
                 'attributes' => [
                     'email' => null,
                     'phone' => null,
@@ -274,7 +277,7 @@ class SerializerTest extends TestCase
                     'payment' => [
                         'data' => [
                             'type' => 'order/payment-card',
-                            'id' => 1,
+                            'id' => '1',
                         ],
                     ],
                     'items' => [
@@ -285,7 +288,7 @@ class SerializerTest extends TestCase
             'included' => [
                 [
                     'type' => 'order/payment-card',
-                    'id' => 1,
+                    'id' => '1',
                     'attributes' => [
                         'amount' => 10,
                         'type' => 'card',
@@ -294,13 +297,13 @@ class SerializerTest extends TestCase
             ]
         ]);
 
-        $order = new Order();
-        $order->setId(2);
-        $order->setPayment($cashPayment);
+        $order = (new Order())
+            ->setId(2)
+            ->setPayment($cashPayment);
 
         $serialized = $this->jsonApiSerializer->serialize(
             $order,
-            'json',
+            self::FORMAT_JSON,
             Serializer\SerializationContext::create()->setSerializeNull(true)
         );
 
@@ -311,7 +314,7 @@ class SerializerTest extends TestCase
         $this->assertSame(json_decode($serialized, 1), [
             'data' => [
                 'type' => 'order',
-                'id' => 2,
+                'id' => '2',
                 'attributes' => [
                     'email' => null,
                     'phone' => null,
@@ -324,7 +327,7 @@ class SerializerTest extends TestCase
                     'payment' => [
                         'data' => [
                             'type' => 'order/payment-cash',
-                            'id' => 2,
+                            'id' => '2',
                         ],
                     ],
                     'items' => [
@@ -335,7 +338,7 @@ class SerializerTest extends TestCase
             'included' => [
                 [
                     'type' => 'order/payment-cash',
-                    'id' => 2,
+                    'id' => '2',
                     'attributes' => [
                         'amount' => 20,
                         'type' => 'cash',


### PR DESCRIPTION
**1.** Fixed id field to be always string due to specification.
Specification says: Every resource object MUST contain an id member and a type member. The values of the id and type members MUST be strings.

**2.** Some convenience for test objects creation has been added.
**3.** Minor phpdocs changes