### PR TITLE
Empty data serialization & Violation-based Error Handling

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,6 +42,10 @@
         <service id="json_api.resolver.base_uri.default" class="Mango\Bundle\JsonApiBundle\Resolver\BaseUri\BaseUriResolver">
             <argument>%json_api.base_uri%</argument>
         </service>
+
+        <service id="jms_serializer.json_api_constraint_violation_handler" class="Mango\Bundle\JsonApiBundle\Serializer\Handler\ConstraintViolationHandler" public="true">
+            <tag name="jms_serializer.subscribing_handler" />
+        </service>
     </services>
 
 </container>

--- a/Serializer/Handler/ConstraintViolationHandler.php
+++ b/Serializer/Handler/ConstraintViolationHandler.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * (c) Steffen Brem <steffenbrem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mango\Bundle\JsonApiBundle\Serializer\Handler;
+
+use JMS\Serializer\Context;
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\JsonSerializationVisitor;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Constraint violation handler
+ *
+ * @author Sergey Chernecov <sergey.chernecov@gmail.com>
+ */
+class ConstraintViolationHandler implements SubscribingHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribingMethods()
+    {
+        return [
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => ConstraintViolationList::class,
+                'format'    => 'json',
+                'method'    => 'serializeConstraintViolationList'
+            ],
+            [
+                'direction' => GraphNavigator::DIRECTION_SERIALIZATION,
+                'type'      => ConstraintViolation::class,
+                'format'    => 'json',
+                'method'    => 'serializeConstraintViolation'
+            ]
+        ];
+    }
+
+    /**
+     * Serialize constraint violation list
+     *
+     * @param JsonSerializationVisitor $visitor
+     * @param ConstraintViolationList  $list
+     * @param array                    $type
+     * @param Context                  $context
+     *
+     * @return array
+     */
+    public function serializeConstraintViolationList(JsonSerializationVisitor $visitor, ConstraintViolationList $list, array $type, Context $context)
+    {
+        return $visitor->visitArray(iterator_to_array($list), $type, $context);
+    }
+
+    /**
+     * Serialize constraint violation
+     *
+     * @param JsonSerializationVisitor $visitor
+     * @param ConstraintViolation      $violation
+     *
+     * @return array
+     */
+    public function serializeConstraintViolation(JsonSerializationVisitor $visitor, ConstraintViolation $violation)
+    {
+        $data = [
+            'code'   => $violation->getCode(),
+            'title'  => 'Validation Failed',
+            'detail' => $violation->getMessage()
+        ];
+
+        if (null === $visitor->getRoot()) {
+            $visitor->setRoot($data);
+        }
+
+        return $data;
+    }
+}

--- a/Serializer/Handler/ConstraintViolationHandler.php
+++ b/Serializer/Handler/ConstraintViolationHandler.php
@@ -12,6 +12,7 @@ use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
 use JMS\Serializer\Handler\SubscribingHandlerInterface;
 use JMS\Serializer\JsonSerializationVisitor;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
@@ -69,9 +70,14 @@ class ConstraintViolationHandler implements SubscribingHandlerInterface
     public function serializeConstraintViolation(JsonSerializationVisitor $visitor, ConstraintViolation $violation)
     {
         $data = [
+            'status' => Response::HTTP_UNPROCESSABLE_ENTITY,
             'code'   => $violation->getCode(),
             'title'  => 'Validation Failed',
-            'detail' => $violation->getMessage()
+            'detail' => $violation->getMessage(),
+            'meta' => [
+                'property_path' => $violation->getPropertyPath(),
+                'invalid_value' => $violation->getInvalidValue()
+            ]
         ];
 
         if (null === $visitor->getRoot()) {

--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -225,7 +225,7 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
                 $root['links'] = $links;
             }
 
-            if (is_array($errors)) {
+            if (is_array($errors) && count($errors) > 0) {
                 $root['errors'] = $errors;
             } else {
                 $root['data'] = $data;

--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -11,8 +11,6 @@
 
 namespace Mango\Bundle\JsonApiBundle\Serializer;
 
-use Hateoas\Representation\CollectionRepresentation;
-use Hateoas\Representation\PaginatedRepresentation;
 use JMS\Serializer\Accessor\AccessorStrategyInterface;
 use JMS\Serializer\Context;
 use JMS\Serializer\JsonSerializationVisitor;
@@ -21,6 +19,7 @@ use JMS\Serializer\Metadata\ClassMetadata;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use Mango\Bundle\JsonApiBundle\EventListener\Serializer\JsonEventSubscriber;
 use Metadata\MetadataFactoryInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * @author Steffen Brem <steffenbrem@gmail.com>
@@ -37,6 +36,9 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
      */
     protected $showVersionInfo;
 
+    /**
+     * @var bool
+     */
     protected $isJsonApiDocument = false;
 
     /**
@@ -96,11 +98,25 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
         return $root;
     }
 
+    /**
+     * Build json api root
+     *
+     * @param mixed      $data
+     * @param array|null $meta
+     *
+     * @return array
+     */
     protected function buildJsonApiRoot($data, array $meta = null)
     {
-        $root = array(
-            'data' => $data,
-        );
+        if ($data instanceof ConstraintViolationListInterface) {
+            $root = [
+                'errors' => $data,
+            ];
+        } else {
+            $root = [
+                'data' => $data,
+            ];
+        }
 
         if ($meta) {
             $root['meta'] = $meta;
@@ -133,6 +149,10 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
             return true;
         }
 
+        if ($data instanceof ConstraintViolationListInterface) {
+            return true;
+        }
+
         return $this->isResource($data);
     }
 
@@ -147,16 +167,12 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
 
         $root = $this->getRoot();
 
-        // TODO: Error handling
-        if (isset($root['data']) && array_key_exists('errors', $root['data'])) {
-            return parent::getResult();
-        }
-
         if ($root) {
             $data = array();
             $meta = array();
             $included = array();
             $links = array();
+            $errors = array();
 
             if (array_key_exists('data', $root)) {
                 $data = $root['data'];
@@ -172,6 +188,10 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
 
             if (isset($root['links'])) {
                 $links = $root['links'];
+            }
+
+            if (isset($root['errors'])) {
+                $errors = $root['errors'];
             }
 
             if (!is_null($data)) {
@@ -205,10 +225,13 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
                 $root['links'] = $links;
             }
 
-            $root['data'] = $data;
-
-            if ($included) {
-                $root['included'] = array_values($included);
+            if (is_array($errors)) {
+                $root['errors'] = $errors;
+            } else {
+                $root['data'] = $data;
+                if ($included) {
+                    $root['included'] = array_values($included);
+                }
             }
 
             $this->setRoot($root);

--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -48,6 +48,7 @@ final class Serializer implements SerializerInterface
 
         if ($format === 'json') {
             $context->addExclusionStrategy($this->exclusionStrategy);
+            $context->setSerializeNull(true);
         }
 
         return $this->jmsSerializer->serialize($data, $format, $context);

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/validator": "~2.3|~3.0",
         "jms/serializer-bundle": "~0.13|~1.0|~2.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"


### PR DESCRIPTION
**Provide a possibility to serialize empty data**

> Primary data MUST be either:
> - a single resource object, a single resource identifier object, **or null, for requests that target single resources**
> - an array of resource objects, an array of resource identifier objects, **or an empty array ([]), for requests that target resource collections**

**Error handling based on Validation constraints has been added**